### PR TITLE
One-to-one mapping of Moosh-Spotify accounts

### DIFF
--- a/frontend/src/api/auth.js
+++ b/frontend/src/api/auth.js
@@ -1,4 +1,5 @@
 import Cookies from 'js-cookie';
+import { updateRefreshToken } from './firebase';
 
 const STR_SIZE = 64;
 const clientId = process.env.REACT_APP_CLIENT_ID;
@@ -43,6 +44,7 @@ const getToken = async (fromRefresh = false) => {
 
     Cookies.set('token', response.access_token, { expires: new Date(new Date().getTime() + response.expires_in * 1000), secure: true });
     Cookies.set('refresh_token', response.refresh_token, { expires: 7, secure: true });
+    await updateRefreshToken(response.refresh_token);
 
     // clear code query in URL to avoid reuse and send to curator after login
     window.history.replaceState({}, document.title, "/");

--- a/frontend/src/api/firebase.js
+++ b/frontend/src/api/firebase.js
@@ -39,6 +39,7 @@ export const firebaseSignup = async (email, password) => {
     const userObject = {
       email: cred.user.email,
       spotifyUri: null,
+      refreshToken: null,
       createdAt: new Date().toISOString(),
     };
 
@@ -62,16 +63,31 @@ export const firebaseSignout = async () => {
 
 export const updateSpotifyURI = async (uri) => {
   try {
-    const userRef = await doc(db, "users", firebaseAuth.currentUser.uid);
+    const userRef = doc(db, "users", firebaseAuth.currentUser.uid);
     const userSnapshot = await getDoc(userRef);
 
     if (userSnapshot.exists()) {
-      // If the user document exists, update the spotifyUri field
-      await setDoc(userRef, { spotifyUri: uri }, { merge: true });
+      const data = userSnapshot.data();
+      if (!!!data.spotifyUri) {
+        await setDoc(userRef, { spotifyUri: uri }, { merge: true });
+      }
       return 0;
     } else {
       console.error("User document does not exist.");
       return -1;
+    }
+  } catch (e) {
+    console.error(e);
+  }
+};
+
+export const updateRefreshToken = async (token) => {
+  try {
+    const userRef = doc(db, "users", firebaseAuth.currentUser.uid);
+    const userSnapshot = await getDoc(userRef);
+
+    if (userSnapshot.exists()) {
+      await setDoc(userRef, { refreshToken: token }, { merge: true });
     }
   } catch (e) {
     console.error(e);

--- a/frontend/src/components/CuratorSettingsDrawer.jsx
+++ b/frontend/src/components/CuratorSettingsDrawer.jsx
@@ -8,7 +8,7 @@ const SETTINGS = {
   ACOUSTICNESS: "acousticness"
 };
 
-const CuratorSettingsDrawer = ({ visible, toggleDrawer, settings, setSettings }) => {
+const CuratorSettingsDrawer = ({ toggleDrawer, settings, setSettings }) => {
   const setNumSongs = n => {
     setSettings(prevSettings => {
       return {

--- a/frontend/src/pages/Auth/Login.jsx
+++ b/frontend/src/pages/Auth/Login.jsx
@@ -2,9 +2,10 @@ import React, { useState, useEffect } from "react";
 import { useNavigate } from "react-router-dom";
 import { Input } from "@chakra-ui/react";
 import { ButtonPrimary} from "../../components/ButtonPrimary";
-import { firebaseLogin } from "../../api/firebase";
+import { fetchUserData, firebaseLogin } from "../../api/firebase";
 import { authorize } from "../../api/auth";
 import { useAuth } from "../../contexts/AuthProvider";
+import Cookies from "js-cookie";
 
 const Login = () => {
   const [email, setEmail] = useState("");
@@ -28,7 +29,10 @@ const Login = () => {
       if (!!!res) {
         setError(true);
       } else {
-        authorize(true);
+        fetchUserData().then(data => {
+          Cookies.set('refresh_token', data.refreshToken, { expires: 7, secure: true });
+          authorize(false);
+        });
       }
     });
   };

--- a/frontend/src/pages/Curator/Curator.jsx
+++ b/frontend/src/pages/Curator/Curator.jsx
@@ -286,7 +286,6 @@ const Curator = () => {
             onSubmit={onSubmit}
             prompt={prompt}
             onChangePrompt={onChangePrompt}
-            settingsDrawerVisible={settingsDrawerVisible}
             toggleSettingsDrawer={toggleSettingsDrawer}
             settings={settings}
             setSettings={setSettings}

--- a/frontend/src/pages/Curator/views/PromptView.jsx
+++ b/frontend/src/pages/Curator/views/PromptView.jsx
@@ -7,7 +7,6 @@ const PromptView = ({
   onSubmit,
   prompt,
   onChangePrompt,
-  settingsDrawerVisible,
   toggleSettingsDrawer,
   settings,
   setSettings
@@ -30,7 +29,6 @@ const PromptView = ({
             onClick={toggleSettingsDrawer}
           />
           <CuratorSettingsDrawer
-            visible={settingsDrawerVisible}
             toggleDrawer={toggleSettingsDrawer}
             settings={settings}
             setSettings={setSettings}


### PR DESCRIPTION
- Removes ability to link a new Spotify account at Login
- Stores refresh token in firebase user doc to be used at Login
- The account connected at sign up is the account used permanently