### PR TITLE
Merged feature/kpi-tracking with main

### DIFF
--- a/api/model.py
+++ b/api/model.py
@@ -9,7 +9,7 @@ from openai import OpenAI
 from tenacity import retry, wait_random_exponential, stop_after_attempt
 from termcolor import colored
 
-GPT_MODEL_NEW = "gpt-4-turbo-2024-04-09"
+GPT_MODEL_NEW = "gpt-3.5-turbo-0125"
 client = OpenAI()
 
 @retry(wait=wait_random_exponential(multiplier=1, max=40), stop=stop_after_attempt(3))

--- a/frontend/src/api/kpis.js
+++ b/frontend/src/api/kpis.js
@@ -1,0 +1,195 @@
+import { authenticate } from "./auth";
+import { db, firebaseAuth } from "./firebase";
+import {
+  collection,
+  addDoc,
+  doc,
+  setDoc,
+  updateDoc,
+  getDoc,
+} from "firebase/firestore";
+
+/* Utility functions for adding KPI tracking documents to firestore. Each KPI
+ * document has the structure:
+ * uid: string,
+ * type: string,
+ * timestamp: time,
+ * data: Object
+ */
+
+// Increment the count of instance displayed on parent document.
+const incrementCount = async (actionId) => {
+  const docSnap = await getDoc(doc(db, "kpis", actionId));
+  const curr = docSnap.data().num_instances;
+
+  try {
+    await updateDoc(doc(db, "kpis", actionId), {
+      num_instances: curr + 1,
+    });
+    return true;
+  } catch (error) {
+    console.error("Failed to increment instances", error);
+  }
+};
+
+// PROMPTING KPIS
+// Number of keystrokes and length of the submitted prompt. Will need to find
+// prompt by searching through uid and promptId.
+const logPrompt = async (
+  numKeystrokes,
+  numTracks,
+  promptLength,
+  promptId,
+  sessionId
+) => {
+  if (process.env.REACT_APP_MODE !== "PROD") {
+    console.log("Prompt not logged, in dev.");
+    return;
+  }
+
+  const uid = firebaseAuth.currentUser?.uid;
+  const actionId = "prompt_submitted";
+
+  try {
+    const promptData = {
+      uid: uid,
+      timestamp: new Date().toISOString(),
+      sessionId,
+      data: {
+        numKeystrokes,
+        numTracks: numTracks,
+        promptLength: promptLength,
+        promptId: promptId,
+      },
+    };
+
+    const docRef = await setDoc(
+      doc(db, "kpis", actionId, "instances", promptId),
+      promptData
+    );
+
+    incrementCount(actionId);
+    return docRef.id;
+  } catch (error) {
+    console.error("Error logging prompting data: ", error);
+  }
+};
+
+// Log when a user clicks the regeneration button. Use promptId from metadata
+// to match with promptIds of the prompt_submitted action instances.
+const logRegeneration = async (
+  numToggles,
+  numToggleAlls,
+  numPreviewPlays,
+  numLinkClicks,
+  numNewTracks,
+  promptId,
+  sessionId
+) => {
+  if (process.env.REACT_APP_MODE !== "PROD") {
+    console.log("Prompt not logged, in dev.");
+    return;
+  }
+
+  const uid = firebaseAuth.currentUser?.uid;
+  const actionId = "regenerate_clicked";
+
+  try {
+    const regenerationData = {
+      uid,
+      timestamp: new Date().toISOString(),
+      sessionId,
+      data: {
+        numToggles,
+        numToggleAlls,
+        numPreviewPlays,
+        numLinkClicks,
+        numNewTracks,
+        promptId,
+      },
+    };
+
+    const docRef = await addDoc(
+      collection(db, "kpis", actionId, "instances"),
+      regenerationData
+    );
+    incrementCount(actionId);
+    return docRef.id;
+  } catch (error) {
+    console.error("Error logging regeneration data: ", error);
+  }
+};
+
+const logExport = async (numRegenerations, playlistId, promptId, sessionId) => {
+  if (process.env.REACT_APP_MODE === "DEV") {
+    console.log("Export not logged, in dev.");
+    return;
+  }
+  const uid = firebaseAuth.currentUser?.uid;
+  const actionId = "export_clicked";
+
+  try {
+    const exportData = {
+      uid,
+      timestamp: new Date().toISOString(),
+      sessionId,
+      data: {
+        numRegenerations,
+        playlistId,
+        promptId,
+      },
+    };
+
+    await setDoc(
+      doc(db, "kpis", actionId, "instances", playlistId),
+      exportData
+    );
+
+    incrementCount(actionId);
+    return playlistId;
+  } catch (error) {
+    console.error("Error logging export data: " + error);
+  }
+};
+
+const logSession = async (tryItMode) => {
+  if (process.env.REACT_APP_MODE !== "PROD") {
+    console.log("Prompt not logged, in dev.");
+    return;
+  }
+  const sleep = (ms) => {
+    return new Promise((resolve) => setTimeout(resolve, ms));
+  };
+
+  // Sleep so uid is initialized.
+  await sleep(1000);
+  const uid = firebaseAuth.currentUser?.uid;
+  const actionId = "curator_session";
+
+  try {
+    const sessionData = {
+      uid,
+      timestamp: new Date().toISOString(),
+      tryItMode,
+    };
+
+    const docRef = await addDoc(
+      collection(db, "kpis", actionId, "instances"),
+      sessionData
+    );
+    incrementCount(actionId);
+    return docRef.id;
+  } catch (error) {
+    console.error("Error logging session: " + error);
+  }
+  return;
+};
+
+const kpis = {
+  logPrompt,
+  logRegeneration,
+  logExport,
+  logSession,
+};
+
+export default kpis;

--- a/frontend/src/components/ChoiceLayer.jsx
+++ b/frontend/src/components/ChoiceLayer.jsx
@@ -24,16 +24,24 @@ const ChoiceLayer = ({
   disabled = false,
   unselectedCount,
   selectedCount,
-  tryItMode
+  tryItMode,
 }) => {
   const { onOpen, onClose, isOpen } = useDisclosure();
-  const [ openModal, setOpenModal ] = useState(false);
+  const [openModal, setOpenModal] = useState(false);
   const firstFieldRef = useRef(null);
 
   return (
     <div className="w-3/4 flex space-x-8">
-      {openModal && <SignUpModal closeModal={setOpenModal} modalOpen={openModal} />}
-      <Tooltip label={isOpen ? undefined : `Export ${selectedCount} track${selectedCount === 1 ? '' : 's'}`}>
+      {openModal && (
+        <SignUpModal closeModal={setOpenModal} modalOpen={openModal} />
+      )}
+      <Tooltip
+        label={
+          isOpen
+            ? undefined
+            : `Export ${selectedCount} track${selectedCount === 1 ? "" : "s"}`
+        }
+      >
         <div className="w-full bg-secondary py-2 px-6 rounded-md hover:cursor-pointer font-semibold text-white flex justify-center items-center">
           <Popover
             isOpen={isOpen}
@@ -69,7 +77,9 @@ const ChoiceLayer = ({
                   />
                   <div
                     className={`rounded-md w-12 h-10 ${
-                      disabled ? "bg-gray-100" : "bg-secondary hover:cursor-pointer"
+                      disabled
+                        ? "bg-gray-100"
+                        : "bg-secondary hover:cursor-pointer"
                     } flex justify-center items-center text-white`}
                     onClick={() => {
                       if (tryItMode) {
@@ -88,15 +98,31 @@ const ChoiceLayer = ({
           </Popover>
         </div>
       </Tooltip>
-      
-      <Tooltip label={`Regenerate ${unselectedCount === 0 ? selectedCount : unselectedCount} track${unselectedCount === 1 ? '' : 's'}`}>
-      <div
-        className="w-full bg-primary py-2 px-6 rounded-md hover:cursor-pointer font-semibold text-white flex justify-center items-center"
-        onClick={async () => await onRegenerate()}
+
+      <Tooltip
+        label={
+          unselectedCount === 0
+            ? "Deselect songs to regenerate playlist"
+            : `Regenerate ${unselectedCount} song${
+                unselectedCount > 1 ? "s" : ""
+              }`
+        }
       >
-        <GrCycle />
+        <div
+          className={`w-full py-2 px-6 rounded-md font-semibold flex justify-center items-center ${
+            unselectedCount === 0
+              ? "bg-gray-200 text-gray-400"
+              : "bg-primary text-white hover:cursor-pointer"
+          }`}
+          onClick={
+            unselectedCount !== 0
+              ? async () => await onRegenerate(true)
+              : undefined
+          }
+        >
+          <GrCycle />
           <p className="w-full text-center">Regenerate</p>
-      </div>
+        </div>
       </Tooltip>
       <div
         className="w-full bg-gray-200 py-2 px-6 rounded-md hover:cursor-pointer text-surface font-semibold flex justify-center items-center"

--- a/frontend/src/components/History/HistoryDrawer.jsx
+++ b/frontend/src/components/History/HistoryDrawer.jsx
@@ -1,11 +1,7 @@
 import React, { useEffect, useState } from "react";
 import { FaChevronLeft, FaChevronRight } from "react-icons/fa";
 import HistoryItem from "./HistoryItem";
-import {
-  getPlaylistsForUser,
-  getPromptsForUser,
-  getSongsForPrompt,
-} from "../../api/history";
+import history from "../../api/history";
 import { useAuth } from "../../contexts/AuthProvider";
 
 const DAY_OFS = 24 * 60 * 60 * 1000;
@@ -22,7 +18,7 @@ const TimeIndexedList = ({
       window.open(item.url, "_blank");
       return;
     }
-    const songs = await getSongsForPrompt(item.id);
+    const songs = await history.getSongsForPrompt(item.id);
     onClickCallback(songs, item);
   };
 
@@ -109,8 +105,11 @@ const HistoryDrawer = ({ toggleDrawer, visible, onClickCallback }) => {
   // Refetches data every time visible state is changed.
   useEffect(() => {
     if (uid) {
-      const unsubscribeHistory = getPromptsForUser(setHistoryData, uid);
-      const unsubscribePlaylists = getPlaylistsForUser(setPlaylistData, uid);
+      const unsubscribeHistory = history.getPromptsForUser(setHistoryData, uid);
+      const unsubscribePlaylists = history.getPlaylistsForUser(
+        setPlaylistData,
+        uid
+      );
 
       return () => {
         unsubscribeHistory();
@@ -120,7 +119,9 @@ const HistoryDrawer = ({ toggleDrawer, visible, onClickCallback }) => {
   }, [uid]);
 
   useEffect(() => {
-    const sortedHistory = historyData.sort((a, b) => new Date(b.timestamp) - new Date(a.timestamp));
+    const sortedHistory = historyData.sort(
+      (a, b) => new Date(b.timestamp) - new Date(a.timestamp)
+    );
     setWeekHistory(
       sortedHistory.filter(
         (item) => new Date(item.timestamp) > new Date().getTime() - 7 * DAY_OFS
@@ -173,14 +174,18 @@ const HistoryDrawer = ({ toggleDrawer, visible, onClickCallback }) => {
       >
         <div className="flex space-x-4 sm:space-x-12 items-center justify-center mb-3">
           <div className="space-y-1 hover:cursor-pointer" onClick={toggleTab}>
-            <p className="text-lg sm:text-2xl font-semibold text-surface">History</p>
+            <p className="text-lg sm:text-2xl font-semibold text-surface">
+              History
+            </p>
             <div
               id="history-bar"
               className="w-full h-1 rounded-md bg-secondary"
             />
           </div>
           <div className="space-y-1 hover:cursor-pointer" onClick={toggleTab}>
-            <p className="text-lg sm:text-2xl font-semibold text-surface">Playlists</p>
+            <p className="text-lg sm:text-2xl font-semibold text-surface">
+              Playlists
+            </p>
             <div
               id="playlist-bar"
               className="w-full h-1 rounded-md bg-secondary/[0.3]"

--- a/frontend/src/components/History/HistoryItem.jsx
+++ b/frontend/src/components/History/HistoryItem.jsx
@@ -2,7 +2,7 @@ import React, { useState } from "react";
 import { BsThreeDots } from "react-icons/bs";
 import { MdDelete } from "react-icons/md";
 import Popover from "../Popover";
-import { deletePrompt } from "../../api/history";
+import history from "../../api/history";
 import { Tooltip } from "@chakra-ui/react";
 
 const HistoryItem = ({ item, onClick, isPlaylist }) => {
@@ -10,7 +10,7 @@ const HistoryItem = ({ item, onClick, isPlaylist }) => {
   const text = isPlaylist ? item.title : item.prompt;
 
   const onDelete = async () => {
-    await deletePrompt(item.id);
+    await history.deletePrompt(item.id);
   };
 
   const action = (e, func) => {

--- a/frontend/src/components/TrackCard.jsx
+++ b/frontend/src/components/TrackCard.jsx
@@ -4,7 +4,6 @@ import { Checkbox } from "@chakra-ui/react";
 import { useAudio } from "../contexts/AudioProvider";
 import Tooltip from "./Tooltip";
 
-
 const TrackCard = ({
   artist,
   title,
@@ -15,6 +14,8 @@ const TrackCard = ({
   isSelected,
   isNew,
   onToggleSelection,
+  previewCallback,
+  linkCallback,
 }) => {
   const { setSong, stopSong, previewId } = useAudio();
 
@@ -22,13 +23,29 @@ const TrackCard = ({
     return () => {
       stopSong();
     };
-  // eslint-disable-next-line
+    // eslint-disable-next-line
   }, []);
+
+  const onClickPreview = () => {
+    if (previewId !== uri) {
+      previewCallback();
+      setSong(preview, uri);
+    } else {
+      stopSong();
+    }
+  };
+
+  const onClickLink = () => {
+    window.open(url, "_blank");
+    linkCallback();
+  };
 
   return (
     <div
       className={`border border-2 border-surface/[.1] flex py-2 pl-2 pr-4 mb-2 rounded-md 
-      ${isNew ? "bg-primary bg-opacity-10" : ""} ${isSelected ? "" : "bg-opacity-30 bg-disabled brightness-75 grayscale"}`}
+      ${isNew ? "bg-primary bg-opacity-10" : ""} ${
+        isSelected ? "" : "bg-opacity-30 bg-disabled brightness-75 grayscale"
+      }`}
     >
       <div className="flex justify-center items-center w-12 z-0">
         <Checkbox
@@ -41,9 +58,7 @@ const TrackCard = ({
         {!!preview ? (
           <div
             className="rounded-full h-8 w-8 bg-primary flex justify-center items-center hover:cursor-pointer"
-            onClick={() =>
-              previewId !== uri ? setSong(preview, uri) : stopSong()
-            }
+            onClick={onClickPreview}
           >
             {previewId !== uri ? (
               <FaPlay className="text-white" />
@@ -53,16 +68,16 @@ const TrackCard = ({
           </div>
         ) : (
           <Tooltip text="Spotify preview not available">
-          <div className="rounded-full h-8 w-8 bg-disabled flex justify-center items-center">
-            <FaPlay className="text-white" />
-          </div>
+            <div className="rounded-full h-8 w-8 bg-disabled flex justify-center items-center">
+              <FaPlay className="text-white" />
+            </div>
           </Tooltip>
         )}
       </div>
       <div className="w-1/3 px-2">
         <p
           className="font-bold text-md text-black hover:cursor-pointer hover:underline"
-          onClick={() => window.open(url, "_blank")}
+          onClick={onClickLink}
         >
           {title}
         </p>

--- a/frontend/src/pages/Curator/Curator.jsx
+++ b/frontend/src/pages/Curator/Curator.jsx
@@ -1,5 +1,6 @@
-import React, { useState } from "react";
+import React, { useEffect, useState } from "react";
 import { useAuth } from "../../contexts/AuthProvider";
+import kpis from "../../api/kpis";
 
 import CuratorComponent from "../../components/Curator";
 
@@ -21,6 +22,8 @@ const Curator = () => {
   const [url, setUrl] = useState("");
   const { user } = useAuth();
 
+  const [sessionId, setSessionId] = useState("");
+
   // For firestore function calls.
   const [promptIdState, setPromptIdState] = useState("");
   const [historyDrawerVisible, setHistoryDrawerVisible] = useState(false);
@@ -30,16 +33,16 @@ const Curator = () => {
     numSongs: 20,
     danceability: {
       enabled: false,
-      threshold: 5
+      threshold: 5,
     },
     energy: {
       enabled: false,
-      threshold: 5
+      threshold: 5,
     },
     acousticness: {
       enabled: false,
-      threshold: 5
-    }
+      threshold: 5,
+    },
   });
 
   return (


### PR DESCRIPTION
From #47 
Added logging for main actions
1. prompt submission
2. song regeneration
3. exporting playlist
4. curator session

The database is structured:
KPIs
-> action document:
{ name and description of action documents fields }
-> instances subcollection:
{ action and metadata }

Actions are fully described in their firestore documents.

Additionally:
- Refactored history export so functions are called from a `history` object rather than their named export.
- Disabled regeneration when all songs are selected and changed tooltip to reflect this

Closes #46 and closes #44 